### PR TITLE
Add Auto-Masking

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -747,7 +747,7 @@ async function uploadFileCustom(file: File, channelId: string) {
             }
 
             if (settings.store.autoFormat === "Yes") {
-                finalUrlModified = `[${fileName}](${finalUrl})`
+                finalUrlModified = `[${fileName}](${finalUrlModified})`
             }
 
             setTimeout(() => sendTextToChat(`${finalUrlModified} `), 10);


### PR DESCRIPTION
add a tiny little option to automatically mask links according to their filename! 

example: if i upload "hi.txt" to catbox, it'd put `[hi.txt](https://files.catbox.moe/XXXXX.txt)`
i tried to edit the fewest lines of code possible!

also, i noticed the litterbox upload function does not append a space after the link. this does not match the rest of the uploaders!