### PR TITLE
Fixes text formatting when Embed Video Files setting is on.

### DIFF
--- a/native.ts
+++ b/native.ts
@@ -2167,6 +2167,7 @@ export async function uploadFileBuffer(
         customUploaderBodyType?: string;
         loggingLevel?: LoggingLevel;
         uploadTimeout?: number;
+        useEmbedsVideo?: string;
     }
 ): Promise<{ success: boolean; url?: string; fileName?: string; fileSize?: number; uploadId?: string; error?: string; actualUploader?: string; attemptedUploaders?: string[]; }> {
     updateLoggingLevel(uploaderSettings.loggingLevel);
@@ -2403,8 +2404,11 @@ export async function uploadFileBuffer(
                 if (backgroundWinner) {
                     nativeLog.info(`[BigFileUpload] ✅ Background retry succeeded with ${backgroundWinner.uploader}!`);
                     let finalUrl = backgroundWinner.url;
+                    if (uploaderSettings.useEmbedsVideo === "Yes") {
+						finalUrl = "https://embeds.video/" + uploadResult;
+					}
                     if (uploaderSettings.autoFormat === "Yes") {
-                        finalUrl = `[${fileName}](${backgroundWinner.url})`;
+                        finalUrl = `[${fileName}](${finalUrl})`;
                     }
                     return {
                         success: true,
@@ -2424,8 +2428,12 @@ export async function uploadFileBuffer(
 
                 // Format URL if requested
                 let finalUrl = uploadResult;
+                if (uploaderSettings.useEmbedsVideo === "Yes") {
+					finalUrl = "https://embeds.video/" + uploadResult;
+				}
+
                 if (uploaderSettings.autoFormat === "Yes") {
-                    finalUrl = `[${fileName}](${uploadResult})`;
+                    finalUrl = `[${fileName}](${finalUrl})`;
                 }
 
                 // Keep progress for completion message - renderer will clear it via completeUpload()
@@ -2539,8 +2547,11 @@ export async function uploadFileBuffer(
                     if (finalCheck) {
                         nativeLog.info(`[BigFileUpload] ✅ Background retry saved the day with ${finalCheck.uploader}!`);
                         let finalUrl = finalCheck.url;
+                        if (uploaderSettings.useEmbedsVideo === "Yes") {
+						    finalUrl = "https://embeds.video/" + uploadResult;
+					    }
                         if (uploaderSettings.autoFormat === "Yes") {
-                            finalUrl = `[${fileName}](${finalCheck.url})`;
+                            finalUrl = `[${fileName}](${finalUrl})`;
                         }
                         return {
                             success: true,
@@ -2605,6 +2616,7 @@ export async function pickAndUploadFile(
         respectNitroLimit?: boolean;
         nitroTier?: string;
         uploadTimeout?: number;
+        useEmbedsVideo?: string;
     }
 ): Promise<{ success: boolean; url?: string; fileName?: string; fileSize?: number; uploadId?: string; error?: string; actualUploader?: string; attemptedUploaders?: string[]; useNativeUpload?: boolean; buffer?: ArrayBuffer; }> {
     updateLoggingLevel(uploaderSettings.loggingLevel);
@@ -2882,8 +2894,12 @@ export async function pickAndUploadFile(
 
             // Format URL if requested
             let finalUrl = uploadResult;
+            if (uploaderSettings.useEmbedsVideo === "Yes") {
+				finalUrl = "https://embeds.video/" + uploadResult;
+			}
+
             if (uploaderSettings.autoFormat === "Yes") {
-                finalUrl = `[${fileName}](${uploadResult})`;
+                finalUrl = `[${fileName}](${finalUrl})`;
             }
 
             // Return success result

--- a/renderer/formatting.ts
+++ b/renderer/formatting.ts
@@ -44,33 +44,3 @@ function isVideoFile(filename: string): boolean {
     const lowerName = filename.toLowerCase();
     return videoExtensions.some(ext => lowerName.endsWith(ext));
 }
-
-export function wrapWithEmbedsVideo(url: string, filename: string, enabled: boolean): string {
-    if (!enabled || !isVideoFile(filename)) {
-        return url;
-    }
-
-    // Only official embeds.video shorthands (per docs)
-    const shorthandMap: Record<string, string> = {
-        "fileditch.com": "fd",
-        "cdn.discordapp.com": "disc",
-        "catbox.moe": "cat",
-        "0x0.st": "0x0",
-    };
-
-    try {
-        const urlObj = new URL(url);
-        const domain = urlObj.hostname.replace("www.", "");
-
-        for (const [domainKey, code] of Object.entries(shorthandMap)) {
-            if (domain.includes(domainKey)) {
-                const path = urlObj.pathname + urlObj.search;
-                return `https://embeds.video/${code}${path}`;
-            }
-        }
-
-        return `https://embeds.video/${url}`;
-    } catch {
-        return `https://embeds.video/${url}`;
-    }
-}


### PR DESCRIPTION
**Summary** 
Fixes an issue where enabling both _Embed Video Files_ and _Display Original Filename_ resulted in broken/malformed URLs.

**The Problem**
The previous implementation attempted to wrap the final output string with `embeds.video`. This caused two major issues:
- Markdown Breaking: It would produce `https://embeds.video/[filename](url)`, which is invalid and prevents Discord from embedding the link.
- Shorthand Errors: The wrapWithEmbedsVideo function was stripping domains into shorthands (like cat/) which occasionally resulted in dead links.

**The Fix**
- Moved Wrapping Logic: Shifted the logic from renderer/formatting.ts to native.ts.
- Raw URL Handling: The `embeds.video` prefix is now applied directly to the raw URL before it is passed to the autoFormat (Display Original Filename) logic. This ensures the correct `embeds.video` placement.
- Code Cleanup: Simplified index.tsx by removing the manual post-upload URL transformation, as the upload result is now returned fully formatted.

**Verification**
Tested with both settings ON:
- Old Output: `https://embeds.video/[video.mp4](https://link.com)` (Broken)
- New Output: `[video.mp4](https://embeds.video/https://link.com)` (Fixed & Clickable)

Fixes #12 